### PR TITLE
Update code for pytorch 1.9.0

### DIFF
--- a/timesformer/datasets/multigrid_helper.py
+++ b/timesformer/datasets/multigrid_helper.py
@@ -5,6 +5,13 @@
 import numpy as np
 from torch.utils.data.sampler import Sampler
 
+TORCH_MAJOR = int(torch.__version__.split('.')[0])
+TORCH_MINOR = int(torch.__version__.split('.')[1])
+
+if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
+    from torch._six import int_classes as _int_classes
+else:
+    _int_classes = int
 
 class ShortCycleBatchSampler(Sampler):
     """
@@ -20,7 +27,7 @@ class ShortCycleBatchSampler(Sampler):
                 "torch.utils.data.Sampler, but got sampler={}".format(sampler)
             )
         if (
-            not isinstance(batch_size, int)
+            not isinstance(batch_size, _int_classes)
             or isinstance(batch_size, bool)
             or batch_size <= 0
         ):

--- a/timesformer/datasets/multigrid_helper.py
+++ b/timesformer/datasets/multigrid_helper.py
@@ -3,7 +3,6 @@
 """Helper functions for multigrid training."""
 
 import numpy as np
-from torch._six import int_classes as _int_classes
 from torch.utils.data.sampler import Sampler
 
 
@@ -21,7 +20,7 @@ class ShortCycleBatchSampler(Sampler):
                 "torch.utils.data.Sampler, but got sampler={}".format(sampler)
             )
         if (
-            not isinstance(batch_size, _int_classes)
+            not isinstance(batch_size, int)
             or isinstance(batch_size, bool)
             or batch_size <= 0
         ):

--- a/timesformer/datasets/multigrid_helper.py
+++ b/timesformer/datasets/multigrid_helper.py
@@ -3,6 +3,7 @@
 """Helper functions for multigrid training."""
 
 import numpy as np
+import torch
 from torch.utils.data.sampler import Sampler
 
 TORCH_MAJOR = int(torch.__version__.split('.')[0])

--- a/timesformer/models/resnet_helper.py
+++ b/timesformer/models/resnet_helper.py
@@ -12,7 +12,6 @@ from torch import einsum
 from einops import rearrange, reduce, repeat
 import torch.nn.functional as F
 from torch.nn.modules.module import Module
-from torch.nn.modules.linear import _LinearWithBias
 from torch.nn.modules.activation import MultiheadAttention
 
 import numpy as np

--- a/timesformer/models/vit_utils.py
+++ b/timesformer/models/vit_utils.py
@@ -84,7 +84,7 @@ def trunc_normal_(tensor, mean=0., std=1., a=-2., b=2.):
 # From PyTorch internals
 def _ntuple(n):
     def parse(x):
-        if isinstance(x, collections.abc.Iterable):
+        if isinstance(x, container_abcs.Iterable):
             return x
         return tuple(repeat(x, n))
     return parse

--- a/timesformer/models/vit_utils.py
+++ b/timesformer/models/vit_utils.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 from timesformer.models.helpers import load_pretrained
 from .build import MODEL_REGISTRY
 from itertools import repeat
-from torch._six import container_abcs
+import collections.abc
 
 DEFAULT_CROP_PCT = 0.875
 IMAGENET_DEFAULT_MEAN = (0.485, 0.456, 0.406)
@@ -77,7 +77,7 @@ def trunc_normal_(tensor, mean=0., std=1., a=-2., b=2.):
 # From PyTorch internals
 def _ntuple(n):
     def parse(x):
-        if isinstance(x, container_abcs.Iterable):
+        if isinstance(x, collections.abc.Iterable):
             return x
         return tuple(repeat(x, n))
     return parse

--- a/timesformer/models/vit_utils.py
+++ b/timesformer/models/vit_utils.py
@@ -11,7 +11,14 @@ import torch.nn.functional as F
 from timesformer.models.helpers import load_pretrained
 from .build import MODEL_REGISTRY
 from itertools import repeat
-import collections.abc
+
+TORCH_MAJOR = int(torch.__version__.split('.')[0])
+TORCH_MINOR = int(torch.__version__.split('.')[1])
+
+if TORCH_MAJOR == 1 and TORCH_MINOR < 8:
+    from torch._six import container_abcs
+else:
+    import collections.abc as container_abcs
 
 DEFAULT_CROP_PCT = 0.875
 IMAGENET_DEFAULT_MEAN = (0.485, 0.456, 0.406)


### PR DESCRIPTION
The [latest version of pytorch](https://github.com/pytorch/pytorch/commit/58eb23378f2a376565a66ac32c93a316c45b6131#diff-b3c160475f0fbe8ad50310f92d3534172ba98203387a962b7dc8f4a23b15cf4dL35) removed some internal code that this repo imports, such as:

 - `container_abcs` from `torch._six`
 - `int_classes` from `torch._six`

Causing anyone running the current TimeSformer code on new versions of pytorch to receive compile-time errors.
The fix is similar to https://github.com/NVIDIA/apex/pull/1049, checking the user's pytorch version before importing the necessary components.